### PR TITLE
fix

### DIFF
--- a/docs/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/docs/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -4,34 +4,34 @@ title: 手动快速部署
 
 Howdy Partner! This tutorial walks you through:
 
-* Installation of {{< product >}} 2.x
-* Creation of your first cluster
-* Deployment of an application, Nginx
+- Installation of {{< product >}} 2.x
+- Creation of your first cluster
+- Deployment of an application, Nginx
 
-### Quick Start Outline
+## Quick Start Outline
 
 This Quick Start Guide is divided into different tasks for easier consumption.
 
 <!-- TOC -->
 
-01. [Provision a Linux Host](#1-provision-a-linux-host)
+1.  [Provision a Linux Host](#1-provision-a-linux-host)
 
-01. [Install Rancher](#2-install-rancher)
+1.  [Install Rancher](#2-install-rancher)
 
-01. [Log In](#3-log-in)
+1.  [Log In](#3-log-in)
 
-01. [Create the Cluster](#4-create-the-cluster)
+1.  [Create the Cluster](#4-create-the-cluster)
 
 <!-- /TOC -->
 <br/>
 
-#### 1. Provision a Linux Host
+## 1. Provision a Linux Host
 
 Begin creation of a custom cluster by provisioning a Linux host. Your host can be:
 
-* A cloud-host virtual machine (VM)
-* An on-premise VM
-* A bare-metal server
+- A cloud-host virtual machine (VM)
+- An on-premise VM
+- A bare-metal server
 
   > **Note:**
   > When using a cloud-hosted virtual machine you need to allow inbound TCP communication to ports 80 and 443. Please see your cloud-host's documentation for information regarding port configuration.
@@ -40,59 +40,57 @@ Begin creation of a custom cluster by provisioning a Linux host. Your host can b
 
   Provision the host according to our [Requirements](/docs/installation/requirements/).
 
-#### 2. Install Rancher
+## 2. Install Rancher
 
 To install Rancher on your host, connect to it and then use a shell to install.
 
-01.  Log in to your Linux host using your preferred shell, such as PuTTy or a remote Terminal connection.
+1.  Log in to your Linux host using your preferred shell, such as PuTTy or a remote Terminal connection.
 
-02.  From your shell, enter the following command:
+2.  From your shell, enter the following command:
 
-    
-
-``` 
+```
     $ sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 rancher/rancher
-    ```
+```
 
 **Result:** Rancher is installed.
 
-#### 3. Log In
+## 3. Log In
 
 Log in to Rancher to begin using the application. After you log in, you'll make some one-time configurations.
 
-01. Open a web browser and enter the IP address of your host: `https://<SERVER_IP>` .
+1.  Open a web browser and enter the IP address of your host: `https://<SERVER_IP>` .
 
     Replace `<SERVER_IP>` with your host IP address.
 
-02. When prompted, create a password for the default `admin` account there cowpoke!
+2.  When prompted, create a password for the default `admin` account there cowpoke!
 
-03.  Set the **Rancher Server URL**. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL.<br/><br/>If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
+3.  Set the **Rancher Server URL**. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL.<br/><br/>If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
 
 <br/>
 
-#### 4. Create the Cluster
+## 4. Create the Cluster
 
 Welcome to Rancher! You are now able to create your first Kubernetes cluster.
 
 In this task, you can use the versatile **Custom** option. This option lets you add _any_ Linux host (cloud-hosted VM, on-premise VM, or bare-metal) to be used in a cluster.
 
-01. From the **Clusters** page, click **Add Cluster**.
+1.  From the **Clusters** page, click **Add Cluster**.
 
-02. Choose **Custom**.
+2.  Choose **Custom**.
 
-03. Enter a **Cluster Name**.
+3.  Enter a **Cluster Name**.
 
-04. Skip **Member Roles** and **Cluster Options**. We'll tell you about them later.
+4.  Skip **Member Roles** and **Cluster Options**. We'll tell you about them later.
 
-05. Click **Next**.
+5.  Click **Next**.
 
-06. From **Node Role**, select _all_ the roles: **etcd**, **Control**, and **Worker**.
+6.  From **Node Role**, select _all_ the roles: **etcd**, **Control**, and **Worker**.
 
 7.**Optional**: Rancher auto-detects the IP addresses used for Rancher communication and cluster communication. You can override these using `Public Address` and `Internal Address` in the **Node Address** section.
 
-08. Skip the **Labels** stuff. It's not important for now.
+8.  Skip the **Labels** stuff. It's not important for now.
 
-09. Copy the command displayed on screen to your clipboard.
+9.  Copy the command displayed on screen to your clipboard.
 
 10. Log in to your Linux host using your preferred shell, such as PuTTy or a remote Terminal connection. Run the command copied to your clipboard.
 
@@ -102,11 +100,10 @@ In this task, you can use the versatile **Custom** option. This option lets you 
 <br/>
 <br/>
 
-##### Finished
+## Finished
 
 Congratulations! You have created your first cluster.
 
-##### What's Next?
+## What's Next?
 
 Use Rancher to create a deployment. For more information, see [Creating Deployments](/docs/quick-start-guide/workload).
-


### PR DESCRIPTION
- 原文档51-53行使用了代码高亮标记对“```”标记高亮代码，但是没有对齐，导致53行以后的文字全部都成为了代码段的一部分。**已修复**

- 原文档的标题都是三级四级甚至五级的，在右侧导航栏显示不完整。**已修复**

这个commit修复了标记对的问题和标题问题，还没翻译。可以先合入，下周用另一个commit提交翻译后的文档，