### PR TITLE
sync with english doc

### DIFF
--- a/docs/cluster-admin/restoring-etcd/_index.md
+++ b/docs/cluster-admin/restoring-etcd/_index.md
@@ -50,7 +50,7 @@ values={[
 
 <TabItem value="new">
 
-快照由 etcd 中的集群数据，Kubernetes 版本和`cluster.yml`形式的集群配置组成。有了这些快照中的组件，您可以选择如何从快照中恢复集群：
+快照由 etcd 中的集群数据、Kubernetes 版本和`cluster.yml`形式的集群配置组成。您可以使用快照中的这些组件。选择如何从快照中恢复集群：
 
 - **仅恢复 etcd 中的集群数据：** 此还原类似于在 v2.4.0 之前的 Rancher 中还原快照。
 - **恢复 etcd 和 Kubernetes 版本：** 如果由于升级 Kubernetes 版本导致集群出现故障，并且您尚未进行任何集群配置更改，则应使用此选项。

--- a/docs/upgrades/upgrades/ha/_index.md
+++ b/docs/upgrades/upgrades/ha/_index.md
@@ -25,7 +25,7 @@ keywords:
 > **注意：**
 >
 > - [Let's Encrypt 于 2019 年 11 月 1 日开始屏蔽早于 0.8.0 版本的 cert-manager 实例。](https://community.letsencrypt.org/t/blocking-old-cert-manager-versions/98753) 按照[这些说明](/docs/installation/options/upgrading-cert-manager/_index)升级 cert-manager 到最新版本。
-> - 升级指南假定您使用的是 Helm3。如果您是使用 Helm 2 安装的 Rancher，并希望迁移到 Helm 3，请参阅官方的[从 Helm 2 迁移到 Helm 3 的文档](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/)。如果升级到 Helm 3 对您来说是不可行的，我们在[这里](/docs/upgrades/upgrades/ha/helm2/_index)也提供了使用 Helm 2 的升级指南。
+> - 升级指南假定您使用的是 Helm3。如果您是使用 Helm 2 安装的 Rancher，并希望迁移到 Helm 3，请参阅官方的[从 Helm 2 迁移到 Helm 3 的文档](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/)。如果升级到 Helm 3 对您来说是不可行的，我们在[高可用升级指南（ Helm 2）](/docs/upgrades/upgrades/ha/helm2/_index)也提供了使用 Helm 2 的升级指南。
 > - 如果要将 Rancher 从 v2.x 升级到 v2.3+，并且正在使用外部 TLS 终止，则需要编辑 cluster.yml 文件，来[配置 Ingress 使用 use-forwarded-headers](/docs/installation/options/chart-options/_index)。
 
 ## 先决条件
@@ -125,15 +125,15 @@ helm upgrade rancher rancher-<CHART_REPO>/rancher \
    helm delete rancher -n cattle-system
    ```
 
-1. 使用所有的选项将 Rancher 重新安装到最新版本。获取上一步中的所有值，然后使用`--set key=value`。将它们附加到命令中。
+1. 参考[升级 Cert-Manager](/docs/installation/options/upgrading-cert-manager/_index)，卸载并且重新安装`cert-manager`。
+
+1. 使用所有的选项将 Rancher 重新安装到最新版本。获取步骤 1 中的所有值，然后使用`--set key=value`。将它们附加到命令中。
 
    ```
    helm install rancher rancher-<CHART_REPO>/rancher \
    --namespace cattle-system \
    --set hostname=rancher.my.org
    ```
-
-1. 卸载并且重新安装`cert-manager`，请参考[升级 Cert-Manager](/docs/installation/options/upgrading-cert-manager/_index)。
 
 #### 离线安装的 Rancher 高可用升级
 
@@ -142,7 +142,7 @@ helm upgrade rancher rancher-<CHART_REPO>/rancher \
    根据您在安装过程中所做的选择，完成以下过程之一。
 
    | 占位符                           | 描述                                   |
-   | -------------------------------- | -------------------------------------- |
+   | :------------------------------- | :------------------------------------- |
    | `<VERSION>`                      | 输出压缩包的版本号。                   |
    | `<RANCHER.YOURDOMAIN.COM>`       | 您指向负载均衡器的 DNS 名称。          |
    | `<REGISTRY.YOURDOMAIN.COM:PORT>` | 您的私有仓库的 DNS 名称。              |

--- a/docs/upgrades/upgrades/ha/helm2/_index.md
+++ b/docs/upgrades/upgrades/ha/helm2/_index.md
@@ -128,15 +128,15 @@ helm upgrade rancher-<CHART_REPO>/rancher \
 
 如果您当前正在运行版本低于 v0.11 的 cert-manger，并且想将 Rancher 和 cert-manager 都升级到新版本，则由于 cert-manger v0.11 中的 API 更改，您需要重新安装 Rancher 和 cert-manger。
 
-请参阅[升级 Cert-Manger](/docs/installation/options/upgrading-cert-manager/_index)页面以获取更多信息。
-
 1. 卸载 Rancher
 
    ```
    helm delete rancher -n cattle-system
    ```
 
-1. 使用所有的选项将 Rancher 重新安装到最新版本。获取上一步中的所有值，然后使用`--set key=value`。将它们附加到命令中。
+1. 参考[升级 Cert-Manager](/docs/installation/options/upgrading-cert-manager/_index)，卸载并且重新安装`cert-manager`。
+
+1. 使用所有的选项将 Rancher 重新安装到最新版本。获取步骤 1 中的所有值，然后使用`--set key=value`。将它们附加到命令中。
 
    ```
    helm install rancher-<CHART_REPO>/rancher \
@@ -154,7 +154,7 @@ helm upgrade rancher-<CHART_REPO>/rancher \
    根据您在安装过程中所做的选择，完成以下过程之一。
 
    | 占位符                           | 描述                                   |
-   | -------------------------------- | -------------------------------------- |
+   | :------------------------------- | :------------------------------------- |
    | `<VERSION>`                      | 输出压缩包的版本号。                   |
    | `<RANCHER.YOURDOMAIN.COM>`       | 您指向负载均衡器的 DNS 名称。          |
    | `<REGISTRY.YOURDOMAIN.COM:PORT>` | 您的私有仓库的 DNS 名称。              |

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,82 +2,80 @@ const sidebars = require("./sidebars");
 const metadata = require("./metadata");
 
 module.exports = {
-  title: "Rancher 2.x",
-  tagline: "Run Kubernetes Everywhere",
-  baseUrl: "/",
-  url: "https://www.rancher.cn",
-  favicon: "img/favicon.ico",
-  themeConfig: {
-    navbar: {
-      title: "Rancher 2.x",
-      logo: {
-        alt: "Rancher Logo",
-        src: "img/rancher-logo-cow-white.svg"
-      },
-      links: [
-        {
-          href: "https://docs.rancher.cn/",
-          label: "文档中心",
-          position: "left"
+    title: "Rancher 2.x",
+    tagline: "Run Kubernetes Everywhere",
+    baseUrl: "/",
+    url: "https://www.rancher.cn",
+    favicon: "img/favicon.ico",
+    themeConfig: {
+        navbar: {
+            title: "Rancher 2.x",
+            logo: {
+                alt: "Rancher Logo",
+                src: "img/rancher-logo-cow-white.svg",
+            },
+            links: [{
+                    href: "https://docs.rancher.cn/",
+                    label: "文档中心",
+                    position: "left",
+                },
+                { to: "pdf", label: "获取 PDF 文档", position: "left" },
+                {
+                    href: "https://www.rancher.cn/weixin/",
+                    label: "微信",
+                    position: "left",
+                },
+                {
+                    href: "https://www.rancher.cn/",
+                    label: "中国官网",
+                    position: "right",
+                },
+                {
+                    href: "https://rancher.com/support-maintenance-terms/all-supported-versions/",
+                    label: "支持矩阵",
+                    position: "right",
+                },
+                {
+                    href: "https://www.rancher.cn/support/",
+                    label: "技术支持",
+                    position: "right",
+                },
+                {
+                    href: "https://github.com/rancher/rancher",
+                    label: "GitHub",
+                    position: "right",
+                },
+            ],
         },
-        { to: "pdf", label: "获取 PDF 文档", position: "left" },
-        {
-          href: "https://www.rancher.cn/weixin/",
-          label: "微信",
-          position: "left"
+        algolia: {
+            apiKey: "f790c2168867f49bb212aee8c224116d",
+            indexName: "rancher",
         },
-        {
-          href: "https://www.rancher.cn/",
-          label: "中国官网",
-          position: "right"
+        footer: {
+            style: "dark",
+            copyright: `Copyright © ${new Date().getFullYear()} Rancher Labs, Inc. All Rights Reserved. 粤ICP备16086305号`,
         },
-        {
-          href:
-            "https://rancher.com/support-maintenance-terms/all-supported-versions/",
-          label: "支持矩阵",
-          position: "right"
-        },
-        {
-          href: "https://www.rancher.cn/support/",
-          label: "技术支持",
-          position: "right"
-        },
-        {
-          href: "https://github.com/rancher/rancher",
-          label: "GitHub",
-          position: "right"
-        }
-      ]
     },
-    algolia: {
-      apiKey: "f790c2168867f49bb212aee8c224116d",
-      indexName: "rancher"
+    presets: [
+        [
+            "@docusaurus/preset-classic",
+            {
+                docs: {
+                    sidebarPath: require.resolve("./sidebars.js"),
+                    editUrl: "https://github.com/cnrancher/docs-rancher2/edit/dev/",
+                    showLastUpdateAuthor: true,
+                    showLastUpdateTime: true,
+                },
+                theme: {
+                    customCss: require.resolve("./src/css/custom.css"),
+                },
+            },
+        ],
+    ],
+    customFields: {
+        sidebars,
+        metadata,
+        stable: "版本说明 - v2.4.3",
+        baseCommit: "73a1a15ef6fffdb1ecec95c05e353db0497d301e - May 20, 2020",
     },
-    footer: {
-      style: "dark",
-      copyright: `Copyright © ${new Date().getFullYear()} Rancher Labs, Inc. All Rights Reserved. 粤ICP备16086305号`
-    }
-  },
-  presets: [
-    [
-      "@docusaurus/preset-classic",
-      {
-        docs: {
-          sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/cnrancher/docs-rancher2/edit/dev/",
-          showLastUpdateAuthor: true,
-          showLastUpdateTime: true
-        },
-        theme: {
-          customCss: require.resolve("./src/css/custom.css")
-        }
-      }
-    ]
-  ],
-  customFields: {
-    sidebars,
-    metadata,
-    stable: "版本说明 - v2.4.3",
-    baseCommit: "fedbf354f3a1e13a098e9789d7b260afac39ed87 - May 8, 2020"
-  }
 };


### PR DESCRIPTION
Rancher 2.x同步英文文档，这周的英文文档有4处调整，中文文档对应的调整如下：

- cluster-admin/restoring-etcd/_index.md ：can 改为 to，**不涉及中文翻译修改**
- quick-start-guide/deployment/digital-ocean-qs/_index.md：quickstart/aws 改为 quickstart/aws，上个月翻译文档的时候注意到路径有误，已经修改了，**本次不涉及修改**
- upgrades/upgrades/ha/_index.md：步骤顺序调整，**已修改**
- upgrades/upgrades/_index.md：同上，**已修改**

补充说明：
- upgrades/upgrades/ha/_index.md &&  upgrades/upgrades/_index.md：这个地方的问题有点绕，但是把没改动的步骤1翻出之后，一下子就清楚了。
旧版的步骤是1-2-3，步骤2写的“previous step”指向的只能是步骤1 。新版的把步骤顺序改为 1-3-2了，那么它的“previous step”就不是步骤1了，所以这里必须改为“步骤1”。
- cluster-admin/restoring-etcd/_index.md：虽然GitHub显示是修改，实际上修改前后的两段话没有dff，这是误报，不是问题。

Review链接：https://github.com/rancher/docs/compare/fedbf354f3a1e13a098e9789d7b260afac39ed87...master
