### PR TITLE
sync with english doc

### DIFF
--- a/docs/installation/k8s-install/kubernetes-rke/_index.md
+++ b/docs/installation/k8s-install/kubernetes-rke/_index.md
@@ -56,13 +56,15 @@ Rancher Server 只能在使用 RKE 或 K3s 安装的 Kubernetes 集群中运行�
 
    注意：您也可以通过环境变量`$K3S_DATASTORE_ENDPOINT`来配置数据库端点。
 
-  :::note 提示
-   国内用户，可以使用以下方法加速安装：
-   ```
-   curl -sfL https://docs.rancher.cn/k3s/k3s-install.sh | INSTALL_K3S_MIRROR=cn sh -s - server \
-  --datastore-endpoint="mysql://username:password@tcp(hostname:3306)/database-name"
-   ```
-  :::
+:::note 提示
+国内用户，可以使用以下方法加速安装：
+
+```
+curl -sfL https://docs.rancher.cn/k3s/k3s-install.sh | INSTALL_K3S_MIRROR=cn sh -s - server \
+--datastore-endpoint="mysql://username:password@tcp(hostname:3306)/database-name"
+```
+
+:::
 
 1. 在您的另外一台 Linux 节点上执行同样的操作。
 
@@ -190,7 +192,7 @@ services:
   etcd:
     snapshot: true
     creation: 6h
-    retention: 24
+    retention: 24h
 
 # 当使用外部 TLS 终止，并且使用 ingress-nginx v0.22或以上版本时，必须。
 ingress:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,6 +76,6 @@ module.exports = {
         sidebars,
         metadata,
         stable: "版本说明 - v2.4.3",
-        baseCommit: "73a1a15ef6fffdb1ecec95c05e353db0497d301e - May 20, 2020",
+        baseCommit: "edeea536490b4110b1915c429da5fd1cf55a08d6 - May 22, 2020",
     },
 };


### PR DESCRIPTION
Rancher 2.x同步英文文档，截止到周五，英文文档有1处调整，中文文档对应的调整如下： 

installation/k8s-install/kubernetes-rke/_index：“24“ ---> ”24h“

Review链接：https://github.com/rancher/docs/compare/73a1a15ef6fffdb1ecec95c05e353db0497d301e...master
 