### PR TITLE
release note v2.3.0 fix 404

### DIFF
--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -54,7 +54,7 @@ Rancher 2.3.0 版本于 2019 年 10 月 8 日发布。本文介绍了 Rancher 2.
 
 - **支持给节点添加 Taints [[#13972](https://github.com/rancher/rancher/issues/13972)]** - Kubernetes 使用 node taints 来控制哪些工作负载可以被调度到这些节点上。引入给节点添加 Taints 的能力，可以帮助用户更灵活的进行工作负载的调度。Taints 除了可以在“编辑节点”页配置以外，您可以在注册自定义主机时加入 Taints，或在[Node Pool](/docs/cluster-provisioning/rke-clusters/node-pools/_index)和[节点模版](/docs/cluster-provisioning/rke-clusters/node-pools/_index)中对 Taints 进行配置。
 
-* **支持 Google 认证对接 [[#1411](https://github.com/rancher/rancher/issues1411)]** - [您可以使用 Rancher 对接 Google 认证](/docs/admin-settings/authentication/google/_index)。由于 Google 的要求，您的 Rancher Server 必须使用 FQDN。
+* **支持 Google 认证对接 [[#1411](https://github.com/rancher/rancher/issues/1411)]** - [您可以使用 Rancher 对接 Google 认证](/docs/admin-settings/authentication/google/_index)。由于 Google 的要求，您的 Rancher Server 必须使用 FQDN。
 
 * **支持通过 UI 管理 HPA [[#19084](https://github.com/rancher/rancher/issues/19084)]** - 支持通过 UI 管理[Horizontal Pod Autoscaler](/docs/k8s-in-rancher/horitzontal-pod-autoscaler/_index)。
 


### PR DESCRIPTION
修复404链接，原链接里面少打了一个”/“，修改为：https://github.com/rancher/rancher/issues**/**1411