### PR TITLE
weekly 404 fix

### DIFF
--- a/docs/admin-settings/authentication/keycloak/_index.md
+++ b/docs/admin-settings/authentication/keycloak/_index.md
@@ -23,7 +23,7 @@ _v2.1.0 版本可用_
 ## 先决条件
 
 - 您必须有一个[Keycloak IdP 服务器](https://www.keycloak.org/docs/latest/server_installation/)。
-- 在 Keycloak 中，创建一个[新的 SAML 客户端](https://www.keycloak.org/docs/latest/server_admin/#saml-clients)，设置如下。参见[Keycloak 文档](keycloak.org/docs/latest/server_admin/#saml-clients)获得帮助。
+- 在 Keycloak 中，创建一个[新的 SAML 客户端](https://www.keycloak.org/docs/latest/server_admin/#saml-clients)，设置如下。参见[Keycloak 文档](https://keycloak.org/docs/latest/server_admin/#saml-clients)获得帮助。
 
   | 设置                 | 值                                                                      |
   | :------------------- | :---------------------------------------------------------------------- |

--- a/docs/faq/install/_index.md
+++ b/docs/faq/install/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 安装
-description: 
+description:
 keywords:
   - rancher 2.0中文文档
   - rancher 2.x 中文文档
@@ -15,32 +15,32 @@ keywords:
   - 安装
 ---
 
-## Agent无法连接Rancher server
+## Agent 无法连接 Rancher server
 
-### ERROR: https://x.x.x.x/ping is not accessible (Failed to connect to x.x.x.x port 443: Connection timed out)
+### ERROR: `https://x.x.x.x/ping` is not accessible (Failed to connect to x.x.x.x port 443: Connection timed out)
 
 ```bash
 ERROR: https://x.x.x.x/ping is not accessible (Failed to connect to x.x.x.x port 443: Connection timed out)
 ```
 
-在`cattle-cluster-agent`或`cattle-node-agent`中出现以上错误，代表agent无法连接到rancher server，请按照以下步骤排查网络连接：
+在`cattle-cluster-agent`或`cattle-node-agent`中出现以上错误，代表 agent 无法连接到 rancher server，请按照以下步骤排查网络连接：
 
-- 从agent宿主机访问rancher server的443端口，例如：`telnet x.x.x.x 443`
-- 从容器内访问rancher server的443端口，例如：`telnet x.x.x.x 443`
+- 从 agent 宿主机访问 rancher server 的 443 端口，例如：`telnet x.x.x.x 443`
+- 从容器内访问 rancher server 的 443 端口，例如：`telnet x.x.x.x 443`
 
-### ERROR: https://rancher.my.org/ping is not accessible (Could not resolve host: rancher.my.org)
+### ERROR: `https://rancher.my.org/ping` is not accessible (Could not resolve host: rancher.my.org)
 
 ```bash
 ERROR: https://rancher.my.org/ping is not accessible (Could not resolve host: rancher.my.org)
 ```
 
-在`cattle-cluster-agent`或`cattle-node-agent`中出现以上错误，代表agent无法通过域名解析到rancher server，请按照以下步骤进行排查网络连接：
+在`cattle-cluster-agent`或`cattle-node-agent`中出现以上错误，代表 agent 无法通过域名解析到 rancher server，请按照以下步骤进行排查网络连接：
 
-- 从容器内访问通过域名访问rancher server，例如：`ping rancher.my.org`
+- 从容器内访问通过域名访问 rancher server，例如：`ping rancher.my.org`
 
-这个问题在内网并且无DNS服务器的环境下非常常见，即使在/etc/hosts文件中配置了映射关系也无法解决，这是因为`cattle-node-agent`从宿主机的/etc/resolv.conf中继承`nameserver`用作dns服务器。
+这个问题在内网并且无 DNS 服务器的环境下非常常见，即使在/etc/hosts 文件中配置了映射关系也无法解决，这是因为`cattle-node-agent`从宿主机的/etc/resolv.conf 中继承`nameserver`用作 dns 服务器。
 
-所以要解决这个问题，可以在环境中搭建一个dns服务器，配置正确的域名和IP的对应关系，然后将每个节点的`nameserver`指向这个dns服务器。
+所以要解决这个问题，可以在环境中搭建一个 dns 服务器，配置正确的域名和 IP 的对应关系，然后将每个节点的`nameserver`指向这个 dns 服务器。
 
 或者使用[HostAliases](https://kubernetes.io/zh/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/)
 

--- a/docs/installation/options/chart-options/_index.md
+++ b/docs/installation/options/chart-options/_index.md
@@ -29,7 +29,7 @@ keywords:
 ## 高级选项
 
 | 选项                           | 默认值                                                   | 描述                                                                                                           |
-| ------------------------------ | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| :----------------------------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
 | `additionalTrustedCAs`         | false                                                    | `bool` - 参考 [其他受信任的 CA](#其他受信任的-ca)                                                              |
 | `addLocal`                     | "auto"                                                   | `string` - 让 Rancher 检测，并导入"local" Rancher Server 所在的集群。[导入 local 集群](#导入-local-集群)       |
 | `antiAffinity`                 | "preferred"                                              | `string` - 针对 Rancher pods 的 AntiAffinity 规则 - "preferred， required"                                     |
@@ -52,7 +52,7 @@ keywords:
 | `rancherImage`                 | "rancher/rancher"                                        | `string` - rancher 镜像源                                                                                      |
 | `rancherImageTag`              | 跟 chart 版本一样                                        | `string` - rancher 镜像标签                                                                                    |
 | `tls`                          | "ingress"                                                | `string` - 参考 [外部 TLS 终止](#在外部终止-tls)。- "ingress， external"                                       |
-| `systemDefaultRegistry`        | ""                                                       | `string` - 用于所有系统 Docker 镜像的私有 Registry，例如： http://registry.example.com/ _自 v2.3.0 起可用_     |
+| `systemDefaultRegistry`        | ""                                                       | `string` - 用于所有系统 Docker 镜像的私有 Registry，例如： `http://registry.example.com/` _自 v2.3.0 起可用_   |
 | `useBundledSystemChart`        | `false`                                                  | `bool` - 选择使用 Rancher Server 内嵌的 system-charts。这个选项用于离线安装。_自 v2.3.0 起可用_                |
 
 ## 审计日志 API

--- a/docs/installation/options/single-node-install-external-lb/_index.md
+++ b/docs/installation/options/single-node-install-external-lb/_index.md
@@ -244,7 +244,7 @@ openssl s_client -CAfile ca.pem -connect rancher.yourdomain.com:443
 
 ### API 审计日志
 
-如果要使用 Rancher API 记录所有事务，请通过在安装命令中添加以下标志来启用[API 审计](//docs/installation/options/rke-add-on/api-auditing/_index)功能。
+如果要使用 Rancher API 记录所有事务，请通过在安装命令中添加以下标志来启用[API 审计](/docs/installation/options/rke-add-on/api-auditing/_index)功能。
 
     -e AUDIT_LEVEL=1 \
     -e AUDIT_LOG_PATH=/var/log/auditlog/rancher-api-audit.log \

--- a/docs/installation/options/upgrading-cert-manager/helm-2-instructions/_index.md
+++ b/docs/installation/options/upgrading-cert-manager/helm-2-instructions/_index.md
@@ -157,7 +157,7 @@ cert-manager-webhook-5b5dd6999-kst4x            1/1     Running     0          3
 cert-manager-cainjector-3ba5cd2bcd-de332x       1/1     Running     0          3m
 ```
 
-如果"webhook" pod(第二行)处于 ContainerCreating 状态，则它可能仍在等待 Secret 被安装到 pod 中。等几分钟，以免发生这种情况，但是如果遇到问题，请查看 cert-manager[故障排查](https://docs.cert-manager.io/en/latest/getting-started/troubleshooting.html)指南。
+如果"webhook" pod(第二行)处于 ContainerCreating 状态，则它可能仍在等待 Secret 被安装到 pod 中。等几分钟，以免发生这种情况，但是如果遇到问题，请查看 cert-manager[故障排查](https://cert-manager.io/docs/faq/)指南。
 
 > **注意：** 上面的说明要求您将 disable-validation 标签添加到 kube-system 命名空间中。这里有一些外部文档解释了该操作的必要性：
 >

--- a/docs/troubleshooting/dns/_index.md
+++ b/docs/troubleshooting/dns/_index.md
@@ -213,7 +213,7 @@ services:
 
 > **注意：** 由于 kubelet 在容器中运行，因此/etc 和/usr 中的文件的路径位于 kubelet 容器中的/host/etc 和/host/usr 中。
 
-查看[集群 YAML](/docs/k8s-in-rancher/editing-clusters/_index)可以看到如何更改这个配置。集群的配置完成后，您必须删除 kube-dns pod 才能使用 pod 中的新设置：
+查看[集群 YAML](/docs/cluster-admin/editing-clusters/_index)可以看到如何更改这个配置。集群的配置完成后，您必须删除 kube-dns pod 才能使用 pod 中的新设置：
 
 ```
 kubectl delete pods -n kube-system -l k8s-app=kube-dns


### PR DESCRIPTION
本周扫出来10个断链

3个“git.rancher.io/xxxxx”的链接是误报，git可以识别，浏览器不能识别，所以不修改，保持现状

另外7个断链的出现原因主要是：

- “//doc”多打了一根斜杠；

- 外链没加上“https://”前缀，误识别成内部链接；

- 示例链接“x.x.x.ip”没加"`"，误识别成链接；

- Rancher自己的文件架构变动，链接没有修改

- 以及外链的文档架构变动。