### PR TITLE
中文标点改为英文标点

### DIFF
--- a/docs/installation/options/chart-options/_index.md
+++ b/docs/installation/options/chart-options/_index.md
@@ -130,7 +130,7 @@ Rancher 需要访问网络，才能使用某些功能（helm charts）。使用`
 
 ```plain
 --set proxy="http://<username>:<password>@<proxy_url>:<proxy_port>/"
---set noProxy="127.0.0.0/8\，10.0.0.0/8\，172.16.0.0/12\，192.168.0.0/16"
+--set noProxy="127.0.0.0/8\,10.0.0.0/8\,172.16.0.0/12\,192.168.0.0/16"
 ```
 
 ## 其他受信任的 CA


### PR DESCRIPTION
如果是中文标点则配置无效，但不会报错，导致很隐蔽的错误