### PR TITLE
sync with english docs, renew baseCommit in txt

### DIFF
--- a/docs/installation/k8s-install/helm-rancher/_index.md
+++ b/docs/installation/k8s-install/helm-rancher/_index.md
@@ -98,7 +98,7 @@ Rancher 中国技术支持团队建议您使用“您已有的证书” `ingress
 ```
 # 安装 CustomResourceDefinition 资源
 
-kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.0/cert-manager.crds.yaml
 
 # **重要：**
 # 如果您正在运行 Kubernetes v1.15 或更低版本，
@@ -124,7 +124,7 @@ helm repo update
 helm install \
  cert-manager jetstack/cert-manager \
  --namespace cert-manager \
- --version v0.12.0
+ --version v0.15.0
 
 ```
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,6 +78,6 @@ module.exports = {
     sidebars,
     metadata,
     stable: "版本说明 - v2.4.3",
-    baseCommit: "edeea536490b4110b1915c429da5fd1cf55a08d6 - May 22, 2020"
+    baseCommit: "b0922e95c7e14ff9850613ff5b38348db0bf59d4 - June 1, 2020"
   }
 };


### PR DESCRIPTION
Rancher 2.x同步英文文档，这周的英文文档有2处调整，中文文档对应的调整如下： 

installation/k8s-install/helm-rancher/_index：“0.12.0”改为“0.15.0”

Review链接：https://github.com/rancher/docs/compare/edeea536490b4110b1915c429da5fd1cf55a08d6...master