### PR TITLE
add first page in release notes for PDF auto-gen

### DIFF
--- a/docs/rancher2/_index.md
+++ b/docs/rancher2/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 版本概述
-description:
+description: Rancher 2.x 目前有三个大版本：2.3.x、2.4.x 和 2.5.x，每个大版本中有多个小版本，如 2.3.0、2.4.0 和 2.5.0。本文按照版本的发布时间由新到旧罗列了 Rancher 2.3.x、2.4.x 和 2.5.x 中所包含的所有小版本及对应的版本说明。
 keywords:
   - rancher
   - rancher中文
@@ -12,7 +12,7 @@ keywords:
   - rancher 中文文档
   - rancher cn
   - 版本说明
-  - 入门必读
+  - 版本概述
 ---
 
 ## 概述

--- a/docs/rancher2/releases/summary.md
+++ b/docs/rancher2/releases/summary.md
@@ -1,0 +1,58 @@
+---
+title: 版本概述
+description:
+keywords:
+  - rancher
+  - rancher中文
+  - rancher中文文档
+  - rancher官网
+  - rancher文档
+  - Rancher
+  - rancher 中文
+  - rancher 中文文档
+  - rancher cn
+  - 版本说明
+  - 入门必读
+---
+
+## 概述
+
+Rancher 2.x 目前有三个大版本：2.3.x、2.4.x 和 2.5.x，每个大版本中有多个小版本，如 2.3.0、2.4.0 和 2.5.0。
+本文按照版本的发布时间由新到旧罗列了 Rancher 2.3.x、2.4.x 和 2.5.x 中所包含的所有小版本及对应的版本说明。
+
+## 2.5.x
+
+- [2.5.0 版本说明](/docs/rancher2/releases/v2.5.0)
+- [2.5.1 版本说明](/docs/rancher2/releases/v2.5.1)
+- [2.5.2 版本说明](/docs/rancher2/releases/v2.5.2)
+- [2.5.3 版本说明](/docs/rancher2/releases/v2.5.3)
+- [2.5.4 版本说明](/docs/rancher2/releases/v2.5.4)
+- [2.5.5 版本说明](/docs/rancher2/releases/v2.5.5)
+- [2.5.6 版本说明](/docs/rancher2/releases/v2.5.6)
+
+## 2.4.x
+
+- [2.4.0 版本说明](/docs/rancher2/releases/v2.4.0)
+- [2.4.1 版本说明](/docs/rancher2/releases/v2.4.1)
+- [2.4.2 版本说明](/docs/rancher2/releases/v2.4.2)
+- [2.4.3 版本说明](/docs/rancher2/releases/v2.4.3)
+- [2.4.4 版本说明](/docs/rancher2/releases/v2.4.4)
+- [2.4.5 版本说明](/docs/rancher2/releases/v2.4.5)
+- [2.4.6 版本说明](/docs/rancher2/releases/v2.4.6)
+- [2.4.7 版本说明](/docs/rancher2/releases/v2.4.7)
+- [2.4.8 版本说明](/docs/rancher2/releases/v2.4.8)
+- [2.4.9 版本说明](/docs/rancher2/releases/v2.4.9)
+- [2.4.10 版本说明](/docs/rancher2/releases/v2.4.10)
+- [2.4.11 版本说明](/docs/rancher2/releases/v2.4.11)
+
+## 2.3.x
+
+- [2.3.0 版本说明](/docs/rancher2/releases/v2.3.0)
+- [2.3.1 版本说明](/docs/rancher2/releases/v2.3.1)
+- [2.3.2 版本说明](/docs/rancher2/releases/v2.3.2)
+- [2.3.3 版本说明](/docs/rancher2/releases/v2.3.3)
+- [2.3.4 版本说明](/docs/rancher2/releases/v2.3.4)
+- [2.3.5 版本说明](/docs/rancher2/releases/v2.3.5)
+- [2.3.6 版本说明](/docs/rancher2/releases/v2.3.6)
+- [2.3.7 版本说明](/docs/rancher2/releases/v2.3.7)
+- [2.3.8 版本说明](/docs/rancher2/releases/v2.3.8)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,7 +81,7 @@ module.exports = {
     customFields: {
         sidebars,
         metadata,
-        stable: "版本说明 - v2.5.5",
+        stable: "版本说明 - v2.5.6",
         baseCommit: "c0e67713aec743cc019dac28586d681933b97e65 - Mar 3, 2021",
         k3sBaseCommit: "c0e67713aec743cc019dac28586d681933b97e65 - Mar 3, 2021",
     },

--- a/metadata.js
+++ b/metadata.js
@@ -99,7 +99,7 @@ const metadata = {
     },
     docs: {
         rancher2: {
-            "rancher2/releases/summary": "概述",
+            "rancher2/_index": "概述",
             "rancher2/releases/v2.5.6": "版本说明 - v2.5.6",
             "rancher2/releases/v2.5.5": "版本说明 - v2.5.5",
             "rancher2/releases/v2.5.4": "版本说明 - v2.5.4",

--- a/metadata.js
+++ b/metadata.js
@@ -99,6 +99,7 @@ const metadata = {
     },
     docs: {
         rancher2: {
+            "rancher2/releases/summary": "概述",
             "rancher2/releases/v2.5.6": "版本说明 - v2.5.6",
             "rancher2/releases/v2.5.5": "版本说明 - v2.5.5",
             "rancher2/releases/v2.5.4": "版本说明 - v2.5.4",

--- a/sidebars.js
+++ b/sidebars.js
@@ -8,6 +8,7 @@
 module.exports = {
     rancher2: {
         版本说明: [
+            "rancher2/releases/summary",
             "rancher2/releases/v2.5.6",
             "rancher2/releases/v2.5.5",
             "rancher2/releases/v2.5.4",

--- a/sidebars.js
+++ b/sidebars.js
@@ -8,7 +8,7 @@
 module.exports = {
     rancher2: {
         版本说明: [
-            "rancher2/releases/summary",
+            "rancher2/_index",
             "rancher2/releases/v2.5.6",
             "rancher2/releases/v2.5.5",
             "rancher2/releases/v2.5.4",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -71,7 +71,7 @@ function Home() {
                 <div className="navigation__grid">
                     <div className="navigation__item">
                         <div className="navigation__title">
-                            <a href="https://docs.rancher.cn/rancher1/">
+                            <a href="/rancher1">
                                 <h1>Rancher 1.x</h1>
                             </a>
                         </div>
@@ -83,7 +83,7 @@ function Home() {
                     </div>
                     <div className="navigation__item">
                         <div className="navigation__title">
-                            <a href="https://docs.rancher.cn/rancher2/">
+                            <a href="/rancher2">
                                 <h1>Rancher 2.x</h1>
                             </a>
                         </div>
@@ -99,7 +99,7 @@ function Home() {
                     </div>
                     <div className="navigation__item">
                         <div className="navigation__title">
-                            <a href="https://docs.rancher.cn/rke">
+                            <a href="/rke">
                                 <h1>RKE</h1>
                             </a>
                         </div>
@@ -112,7 +112,7 @@ function Home() {
                     </div>
                     <div className="navigation__item">
                         <div className="navigation__title">
-                            <a href="https://docs.rancher.cn/k3s">
+                            <a href="/k3s">
                                 <h1>K3s</h1>
                             </a>
                         </div>
@@ -125,7 +125,7 @@ function Home() {
                     </div>
                     <div className="navigation__item">
                         <div className="navigation__title">
-                            <a href="https://docs.rancher.cn/octopus">
+                            <a href="/octopus">
                                 <h1>Octopus</h1>
                             </a>
                         </div>
@@ -138,7 +138,7 @@ function Home() {
                     </div>
                     <div className="navigation__item">
                         <div className="navigation__title">
-                            <a href="https://docs.rancher.cn/harvester">
+                            <a href="/harvester">
                                 <h1>Harvester</h1>
                             </a>
                         </div>

--- a/src/pages/rancher2.js
+++ b/src/pages/rancher2.js
@@ -113,7 +113,7 @@ function Home() {
                                                             if (
                                                                 "版本说明" ===
                                                                     group.key &&
-                                                                index === 0
+                                                                index === 1
                                                             ) {
                                                                 return (
                                                                     <span


### PR DESCRIPTION
the first page **'summary.md '** was under **docs/rancher2/release** directory. it is renamed as **'_index.md'** and moved to **docs/rancher2** directory.

after testing, sideabar.js and and metadata.js can work well together, such that **'_index.md'** can show up at the first place both in sidebar and in docs.rancher.cn/rancher2/ page. Hence, the 'latest' label should be assign to index[1] instead of index[0] in rancher2.js