### PR TITLE
修改一个错别字

### DIFF
--- a/docs/rancher2.5/cluster-provisioning/production/recommended-architecture/_index.md
+++ b/docs/rancher2.5/cluster-provisioning/production/recommended-architecture/_index.md
@@ -73,7 +73,7 @@ keywords:
 
 添加多个`worker`角色的节点，可以确保在节点出现故障时，Kubernetes 可以重新调度您的工作负载到其他工作节点。
 
-### 为什么对生产环境的 Rancher 集群和下游集群有着不通的要求？
+### 为什么对生产环境的 Rancher 集群和下游集群有着不同的要求？
 
 您可能已经注意到，我们的[Rancehr Server 高可用安装指南](/docs/rancher2.5/installation/install-rancher-on-k8s/_index)并不符合我们对生产就绪集群的定义。因为没有专用的节点作为`worker`节点。但是，对于 Rancehr Server 的部署，这三个节点的集群是有效的，因为：
 


### PR DESCRIPTION
为什么对生产环境的 Rancher 集群和下游集群有着不通的要求？

里面 **不通** 应该是 **不同** ，已经修改